### PR TITLE
special case for modeline that consists solely of '-*- C++ -*-'

### DIFF
--- a/plugin/emacsmodeline.vim
+++ b/plugin/emacsmodeline.vim
@@ -58,6 +58,8 @@ function! <SID>SetVimModeOption(modeline)
             let value = g:emacsModeDict[value]
         endif
         exec 'setlocal filetype=' . value
+    elseif a:modeline =~ '^ *C++ *$'
+        exec 'setlocal filetype=cpp'
     endif
 endfunc
 


### PR DESCRIPTION
C++ header files from libstdc++ such as <vector> have the following modeline:

// <vector> -_\- C++ -_-

This change makes the script recognise it.
