### PR TITLE
improved patch for handling libstdc++ style modelines

### DIFF
--- a/plugin/emacsmodeline.vim
+++ b/plugin/emacsmodeline.vim
@@ -109,6 +109,11 @@ function! ParseEmacsModeLine()
             call <SID>SetVimToggleOption(modeline, 'buffer-read-only',   'readonly',     0)
             call <SID>SetVimToggleOption(modeline, 'indent-tabs-mode',   'expandtab',    1)
 
+            let value = substitute(modeline, '^ *\([^ ]*\) *$', '\L\1', '')
+            if (has_key(g:emacsModeDict, value))
+                exec 'setlocal filetype=' .  g:emacsModeDict[value]
+            endif
+
             " Other emacs options seen in the wild include:
             "  * c-basic-offset: something like tab-width.
             "  * c-file-style: no vim equivalent (?).


### PR DESCRIPTION
the change is where you suggested, and uses the dict instead of hardcoding "C++"
