### PR TITLE
Parse Emacs values until semicolon or whitespace

### DIFF
--- a/plugin/emacsmodeline.vim
+++ b/plugin/emacsmodeline.vim
@@ -85,7 +85,7 @@ function! <SID>SetVimNumberOption(modeline, emacs_name, vim_name)
 endfunc
 
 function! <SID>SetVimToggleOption(modeline, emacs_name, vim_name, nil_value)
-    let value = <SID>FindParameterValue(a:modeline, a:emacs_name, '\S\+')
+    let value = <SID>FindParameterValue(a:modeline, a:emacs_name, '[^; \t]\+')
     if strlen(value)
         if (value == 'nil') == a:nil_value
             exec 'setlocal ' . a:vim_name

--- a/plugin/emacsmodeline.vim
+++ b/plugin/emacsmodeline.vim
@@ -85,7 +85,7 @@ function! <SID>SetVimNumberOption(modeline, emacs_name, vim_name)
 endfunc
 
 function! <SID>SetVimToggleOption(modeline, emacs_name, vim_name, nil_value)
-    let value = <SID>FindParameterValue(a:modeline, a:emacs_name, '[^; \t]\+')
+    let value = <SID>FindParameterValue(a:modeline, a:emacs_name, '[^;[:space:]]\+')
     if strlen(value)
         if (value == 'nil') == a:nil_value
             exec 'setlocal ' . a:vim_name


### PR DESCRIPTION
The former version would find the value "nil;" for the following
Emacs local-variable line:

    // -*- mode: c++; tab-width: 2; indent-tabs-mode: nil; -*-

As a result, SetVimToggleOption would set 'noexpandtab' here.

There's probably a more elegant/robust regex than "[^; \t]" for this.