### PR TITLE
Add protobuf

### DIFF
--- a/plugin/emacsmodeline.vim
+++ b/plugin/emacsmodeline.vim
@@ -44,6 +44,7 @@ let s:emacsModeDictDefault = {
     \ 'shell-script': 'sh',
     \ 'makefile':     'make',
     \ 'js':           'javascript',
+    \ 'protobuf':     'proto',
 \ }
 
 if (!exists('g:emacsModeDict'))


### PR DESCRIPTION
This appears to need a plugin in Emacs. It appears to me that the "protobuf" string is correct for [Google's plugin](https://github.com/google/protobuf/blob/master/editors/protobuf-mode.el) (though I'm not 100 % certain, having next to no experience with Emacs). At any rate that's the string I've seen used by colleagues.
